### PR TITLE
Show uptime also in human-readble form

### DIFF
--- a/lib/Plack/Middleware/ServerStatus/Lite.pm
+++ b/lib/Plack/Middleware/ServerStatus/Lite.pm
@@ -72,7 +72,18 @@ sub _handle_server_status {
         return [403, ['Content-Type' => 'text/plain'], [ 'Forbidden' ]];
     }
 
-    my $body="Uptime: $self->{uptime}\n";
+    my ($upsince, $duration) = (time - $self->{uptime}), "";
+    my @spans = (86400 => 'days', 3600 => 'hours', 60 => 'minutes');
+    while (@spans) {
+        my ($seconds,$unit) = (shift @spans, shift @spans);
+        if ($upsince > $seconds) {
+            $duration .= int($upsince/$seconds) . " $unit, ";
+            $upsince = $upsince % $seconds;
+        }
+    }
+    $duration .= "$upsince seconds";
+
+    my $body="Uptime: $self->{uptime} ($duration)\n";
     if ( my $scoreboard = $self->{__scoreboard} ) {
         my $stats = $scoreboard->read_all();
         my $raw_stats='';


### PR DESCRIPTION
I can make little use of uptime values such as `Uptime: 1325683520` so I extended it to show the value in human-readable form, for instance `Uptime: 1325683520 (2 minutes, 12 seconds)`. No additional dependencies.
