### PR TITLE
Add FreeBSD support for ps(1) command line options.

### DIFF
--- a/lib/Plack/Middleware/ServerStatus/Lite.pm
+++ b/lib/Plack/Middleware/ServerStatus/Lite.pm
@@ -136,9 +136,10 @@ sub _handle_server_status {
         my @all_workers;
         if ( ! $self->skip_ps_command ) {
             my $parent_pid = getppid;
-            my $ps = `LC_ALL=C command ps -e -o ppid,pid`;
+            my $psopt = $^O =~ m/^freebsd$/ ? '-ax' : '-e';
+            my $ps = `LC_ALL=C command ps $psopt -o ppid,pid`;
             $ps =~ s/^\s+//mg;
-        
+
             for my $line ( split /\n/, $ps ) {
                 next if $line =~ m/^\D/;
                 my ($ppid, $pid) = split /\s+/, $line, 2;


### PR DESCRIPTION
Some of ps(1) command options are different from Linux.  This patch adds FreeBSD support for ps(1) options, and maybe other BSD can be applied in this $^O regexp.  But I didn't add here other than FreeBSD for now because I don't have other BSD systems.
