### PR TITLE
Fix JSON types unexpectedly changed at 0.35

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -14,6 +14,7 @@ on 'test' => sub {
     requires 'LWP::UserAgent';
     requires 'Capture::Tiny';
     requires 'Test::SharedFork';
+    requires 'B';
 };
 
 

--- a/lib/Plack/Middleware/ServerStatus/Lite.pm
+++ b/lib/Plack/Middleware/ServerStatus/Lite.pm
@@ -156,7 +156,7 @@ sub _handle_server_status {
     $duration .= "$upsince seconds";
 
     my $body="ServerUptime: $duration\nUptime: $server_uptime_seconds\n";
-    my %status = ( 'Uptime' => $self->{uptime} );
+    my %status = ( 'Uptime' => $self->{uptime} . "");
 
     if ( $self->counter_file ) {
         my ($counter,$bytes) = $self->counter;

--- a/t/04_json.t
+++ b/t/04_json.t
@@ -6,6 +6,7 @@ use Plack::Builder;
 use Plack::Loader;
 use File::Temp;
 use JSON;
+use B;
 
 my @servers;
 for my $server ( qw/Starman Starlet/ ) {
@@ -22,7 +23,7 @@ if ( !@servers ) {
     plan skip_all => 'Starlet or Starman isnot installed';
 }
 else {
-    plan tests => 6 * scalar @servers;
+    plan tests => 7 * scalar @servers;
 }
 
 
@@ -51,6 +52,7 @@ for my $server ( @servers ) {
                 is( $stats->{IdleWorkers}, 3 );
                 is( $stats->{BusyWorkers}, 2 );
                 like ( $stats->{Uptime}, qr/^\d+$/ );
+                ok ((B::svref_2object(\($stats->{Uptime}))->FLAGS & B::SVp_POK ) == B::SVp_POK, 'Uptime is a string, not a number');
                 isa_ok( $stats->{stats}, 'ARRAY');
             }
             elsif ( defined $pid ) {


### PR DESCRIPTION
Before 0.35, `Uptime` parameter from response of `{path}?json` was a JSON string. (its value was quoted by `"`)
But at 0.35, It (maybe unexpectedly) changed to a JSON number, caused by commit 1fd7e6b0dfd05a16630a8ba0d25e367efb52541f.

In pre-0.35, `$self->{uptime}` was flagged as string by string interpolation at https://github.com/kazeburo/Plack-Middleware-ServerStatus-Lite/pull/18/files#diff-1df032baeeed2a3067f85e5d3b0d565dR158 . But 1fd7e6b0dfd05a16630a8ba0d25e367efb52541f removed the interpolation, so JSON::encode_json converts `$stats{Uptime} = $self->{uptime}` to a JSON number.

The change at 0.35 breaks some parser like `mackerel-agent-plugin`, [which expects it's a JSON string](https://github.com/mackerelio/mackerel-agent-plugins/blob/21f267e0e9c8a0ab1e0be2c5aef23d8763e91b30/mackerel-plugin-plack/plack.go#L71).
So I'd like to change it back to JSON String.
